### PR TITLE
Fix typo and blame btn reference on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ When you want to create a crosslink, start typing the title of an issue or pull 
 
 An important part of version control is the ability to look into the past. By using `git blame`, and finding the story behind a commit, we're able to do more than _blame_ people for code. We're able to see the story around why a commit was made. What is the associated pull request? Who approved the pull request? What tests were run on that commit before it was merged?
 
-The obvious reason to find things in history is to know about the history. With issues and pull requests, we see a more complete story about about the history, not just just the bare minimum.
+The obvious reason to find things in history is to know about the history. With issues and pull requests, we see a more complete story about the history, not just just the bare minimum.
 
 ### What's `git blame`?
 
@@ -101,7 +101,7 @@ A SHA is a reference to a specific object. In this case, it's a reference to a c
    - _Tip: you may have previously created your repository in a new tab_
 2. Click `docs` to navigate into the `/docs` directory
 3. Click `_sidebar.md` to view the file
-4. On the top right side of the file, click **Blame** to see the details of the most recent revision
+4. On the top left side of the file, click **Blame** to see the details of the most recent revision
 5. Click the commit message, `add sidebar to documentation` to see the commit details
 6. Copy the first seven characters of the SHA (the first 7 characters of the 40 character hexadecimal string listed after `commit`)
 7. Comment on issue #2 by adding the SHA from step 6 as a comment text and click on "Comment" button


### PR DESCRIPTION
### Why:

Closes https://github.com/skills/connect-the-dots/issues/29

- Fixes `README.md` typo and Blame button reference detailed in issue #29 

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

- Removed the extra "about" from the 2nd paragraph
- Updated step 4 to "On the top left side of the file"

Current Blame Button position:
![image](https://user-images.githubusercontent.com/120277121/220751112-4d2493c2-5faf-4372-959a-f0064b560499.png)

### Check off the following:

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
