### PR TITLE
Update README.md fix reference to Blame Btn

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A SHA is a reference to a specific object. In this case, it's a reference to a c
    - _Tip: you may have previously created your repository in a new tab_
 2. Click `docs` to navigate into the `/docs` directory
 3. Click `_sidebar.md` to view the file
-4. On the top left side of the file, click **Blame** to see the details of the most recent revision
+4. On the top of the file, click **Blame** to see the details of the most recent revision
 5. Click the commit message, `add sidebar to documentation` to see the commit details
 6. Copy the first seven characters of the SHA (the first 7 characters of the 40 character hexadecimal string listed after `commit`)
 7. Comment on issue #2 by adding the SHA from step 6 as a comment text and click on "Comment" button


### PR DESCRIPTION
### Why:

Closes https://github.com/skills/connect-the-dots/issues/29

- Made Blame button reference position more general given it seems to be different depending your browser version. (left or right).

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
- Made Blame button reference position more general given that it seems to be different depending browser versions. (left or right)

### Check off the following:

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).

cc: @sinsukehlab @heiskr 
