### PR TITLE
Fix a syntax warning in the Step 2 workflow

### DIFF
--- a/.github/workflows/2-find-commit-in-history.yml
+++ b/.github/workflows/2-find-commit-in-history.yml
@@ -26,8 +26,12 @@ jobs:
       - id: get_step
         run: |
           echo "current_step=$(cat ./.github/steps/-step.txt)" >> $GITHUB_OUTPUT
+      - id: get_commit_id
+        run: |
+          echo "commit_id=$(cat ./.github/files/SIDEBARCOMMIT)" >> $GITHUB_OUTPUT
     outputs:
       current_step: ${{ steps.get_step.outputs.current_step }}
+      commit_id: ${{ steps.get_commit_id.outputs.commit_id }}
 
   on_fix_the_sidebar_issue_comment:
     name: Check if the issue comment is referencing the correct commit ID
@@ -61,7 +65,7 @@ jobs:
         run: echo '${{ toJSON(github.event.issue) }}'
 
       - name: Check if the issue comment is referencing the required commit ID
-        if: contains(github.event.comment.body, needs.find_commit_id.outputs.find_commit_id)
+        if: contains(github.event.comment.body, needs.get_current_step.outputs.commit_id)
         run: echo 'Found the reference to required commit in the comment'
 
       # Update README from step 2 to step 3.


### PR DESCRIPTION
Restore the commit_id output

### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
Currently, the workflow doesn't properly check if the comment body contains the commit ID.

### Changes
<!-- Describe the changes this pull request introduces. -->
Edit 2-find-commit-in-history.yml
Add the `get_commit_id` step to the `get_current_step` job
Use the `commid_id` output from the `get_commit_id` step

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes: #52

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
